### PR TITLE
64 bit integers

### DIFF
--- a/lib/xml_rpc/decoder.ex
+++ b/lib/xml_rpc/decoder.ex
@@ -108,6 +108,20 @@ defmodule XMLRPC.Decoder do
       int
   end
 
+  # Parse an 'i4' atom (32 bit integer)
+  defp parse_value( {:ValueType, [], [{:"ValueType-i4", [],              int}]}, _options)
+      when is_integer(int)
+  do
+      int
+  end
+
+  # Parse an 'i8' atom (64 bit integer)
+  defp parse_value( {:ValueType, [], [{:"ValueType-i8", [],              int}]}, _options)
+      when is_integer(int)
+  do
+      int
+  end
+
   # Parse a 'float' atom
   defp parse_value( {:ValueType, [], [{:"ValueType-double", [],           float}]}, _options) do
     Float.parse(float)

--- a/lib/xml_rpc/xmlrpc.xsd
+++ b/lib/xml_rpc/xmlrpc.xsd
@@ -66,6 +66,7 @@
   <xsd:complexType name="ValueType" mixed="true">
     <xsd:choice minOccurs="0" maxOccurs="1">
       <xsd:element name="i4"                type="xsd:int" />
+      <xsd:element name="i8"                type="xsd:int" />
       <xsd:element name="int"               type="xsd:int" />
       <xsd:element name="string"            type="ASCIIString" />
       <xsd:element name="double"            type="xsd:decimal" />

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -43,11 +43,14 @@ defmodule XMLRPC.DecoderTest do
 <methodResponse>
    <params>
       <param>
-         <value><i4>17</i4></value>
-      </param>
-
-      <param>
-         <value><i8>1125899906842624</i8></value>
+        <value>
+          <array>
+            <data>
+              <value><i4>17</i4></value>
+              <value><i8>1125899906842624</i8></value>
+            </data>
+           </array>
+         </value>
       </param>
    </params>
 </methodResponse>

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -37,6 +37,26 @@ defmodule XMLRPC.DecoderTest do
   @rpc_simple_response_1_elixir %XMLRPC.MethodResponse{param: 30}
 
 
+  # 2^50 = 1125899906842624 (more than 32 bit)
+  @rpc_bitsize_integer_response_1 """
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+   <params>
+      <param>
+         <value><i4>17</i4></value>
+      </param>
+
+      <param>
+         <value><i8>1125899906842624</i8></value>
+      </param>
+   </params>
+</methodResponse>
+"""
+
+  @rpc_bitsize_integer_response_1_elixir %XMLRPC.MethodResponse{param: [17, 1125899906842624]}
+
+
+
   @rpc_fault_1 """
 <?xml version="1.0" encoding="UTF-8"?>
 <methodResponse>
@@ -246,6 +266,11 @@ defmodule XMLRPC.DecoderTest do
   test "decode rpc_simple_response_1" do
     decode = XMLRPC.decode!(@rpc_simple_response_1)
     assert decode == @rpc_simple_response_1_elixir
+  end
+
+  test "decode rpc_bitsize_integer_response_1" do
+    decode = XMLRPC.decode!(@rpc_bitsize_integer_response_1)
+    assert decode == @rpc_bitsize_integer_response_1_elixir
   end
 
   test "decode rpc_fault_1" do


### PR DESCRIPTION
I use the fantastic elixir-xml_rpc to connect to rtorrent. Its responses have integers encoded as _i8_, because torrents can get very big (in bytes).

This PR adds support to parse these responses.
