### PR TITLE
Parse empty strings correctly.

### DIFF
--- a/lib/xml_rpc/decoder.ex
+++ b/lib/xml_rpc/decoder.ex
@@ -127,6 +127,11 @@ defmodule XMLRPC.Decoder do
     %XMLRPC.DateTime{raw: datetime}
   end
 
+  # Parse an empty 'string' atom
+  defp parse_value( {:ValueType, [], [{:"ValueType-string", [],           []}]}, _options) do
+    ""
+  end
+
   # Parse a 'string' atom
   defp parse_value( {:ValueType, [], [{:"ValueType-string", [],           string}]}, _options) do
     string
@@ -135,6 +140,11 @@ defmodule XMLRPC.Decoder do
   # A string value can optionally drop the type specifier. The node is assumed to be a string value
   defp parse_value( {:ValueType, [], [string]                                     }, _options) when is_binary(string) do
     string
+  end
+
+  # An empty string that drops the type specifier will parse as :undefined instead of an empty binary.
+  defp parse_value( {:ValueType, [], :undefined                                   }, _options) do
+    ""  
   end
 
   # Parse a 'nil' atom

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -205,6 +205,32 @@ defmodule XMLRPC.DecoderTest do
 
   @rpc_response_optional_string_tag_elixir %XMLRPC.MethodResponse{param: "a4sdfff7dad8"}
 
+  @rpc_response_empty_string_tag """
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <params>
+    <param>
+      <value><string></string></value>
+    </param>
+  </params>
+</methodResponse>
+"""
+
+  @rpc_response_empty_string_tag_elixir %XMLRPC.MethodResponse{param: ""}
+
+  @rpc_response_optional_empty_string_tag """
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+  <params>
+    <param>
+      <value></value>
+    </param>
+  </params>
+</methodResponse>
+"""
+
+  @rpc_response_optional_empty_string_tag_elixir %XMLRPC.MethodResponse{param: ""}
+
 
   @rpc_response_invalid_1 """
 <?xml version="1.0" encoding="UTF-8"?>
@@ -276,6 +302,16 @@ defmodule XMLRPC.DecoderTest do
   test "decode rpc_response_optional_string_tag" do
     decode = XMLRPC.decode(@rpc_response_optional_string_tag)
     assert decode == {:ok, @rpc_response_optional_string_tag_elixir}
+  end
+
+  test "decode rpc_response_empty_string_tag" do
+    decode = XMLRPC.decode(@rpc_response_empty_string_tag)
+    assert decode == {:ok, @rpc_response_empty_string_tag_elixir}
+  end
+
+  test "decode rpc_response_empty_string_tag" do
+    decode = XMLRPC.decode(@rpc_response_empty_string_tag)
+    assert decode == {:ok, @rpc_response_empty_string_tag_elixir}
   end
 
   test "decode rpc_response_invalid_1" do

--- a/test/xmlrpc_test.exs
+++ b/test/xmlrpc_test.exs
@@ -309,9 +309,9 @@ defmodule XMLRPC.DecoderTest do
     assert decode == {:ok, @rpc_response_empty_string_tag_elixir}
   end
 
-  test "decode rpc_response_empty_string_tag" do
-    decode = XMLRPC.decode(@rpc_response_empty_string_tag)
-    assert decode == {:ok, @rpc_response_empty_string_tag_elixir}
+  test "decode rpc_response_optional_empty_string_tag" do
+    decode = XMLRPC.decode(@rpc_response_optional_empty_string_tag)
+    assert decode == {:ok, @rpc_response_optional_empty_string_tag_elixir}
   end
 
   test "decode rpc_response_invalid_1" do


### PR DESCRIPTION
An empty string inside a <string> type tag will produce an empty list as
at the XML parser level, which will directly returned in the XMLRPC
response. Handle this case directly.

An empty string with no type produces an :undefined value out of erlsom.
This causes the parser to fail because no parse_value clause will match.
Handle this case directly.

BR. /dalegaard
