### PR TITLE
Use Elixir 1.4 style application dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: elixir
+elixir:
+  - 1.4
+  - 1.5
+  - 1.6
 
 otp_release:
-  - 17.4
-  - 18.3
-  - 19.2
+  - 19.3
+  - 20.1
 
 env: MIX_ENV=test

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ the risk that a malicious client can exhaust out atom space and crash the vm.
 
 ## Installation
 
-Add XML-RPC (and erlsom) to your mix dependencies
+Add XML-RPC to your mix dependencies
 
     def deps do
-      [{:erlsom, github: "willemdj/erlsom"},
-       {:xmlrpc, "~> 0.1"}]
+      [{:xmlrpc, "~> 1.0"}]
     end
 
 Then run `mix deps.get` and `mix deps.compile`.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XmlRpc.Mixfile do
   def project do
     [app: :xmlrpc,
      version: "1.1.0",
-     elixir: "~> 1.0",
+     elixir: "~> 1.4",
      name: "XMLRPC",
      description: "XML-RPC encoder/decder for Elixir. Supports all valid datatypes. Input (ie untrusted) is parsed with erlsom against an xml-schema for security.",
      source_url: "https://github.com/ewildgoose/elixir-xml_rpc",
@@ -18,7 +18,7 @@ defmodule XmlRpc.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: []]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Hello, 

Thanks for creating xmlrpc!

Having to add both `erlsom` and `xmlrpc` as dependencies was a bit confusing.

Since [elixir 1.4](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference) the dependency on `erlsom` can be inferred by mix.

`logger` is also unused, so I removed it as an application dependency.
