### PR TITLE
Bugfix/incorrect float to binary convert

### DIFF
--- a/lib/xml_rpc/encoder.ex
+++ b/lib/xml_rpc/encoder.ex
@@ -55,9 +55,9 @@ defmodule XMLRPC.Encoder do
 
   def encode!(%XMLRPC.MethodResponse{ param: param }, options) do
     ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>"] ++
-    tag("methodResponse",
-      tag("params",
-        encode_param(param, options)))
+      tag("methodResponse",
+        tag("params",
+          encode_param(param, options)))
   end
 
   def encode!(%XMLRPC.Fault{ fault_code: fault_code, fault_string: fault_string }, options) do
@@ -88,7 +88,7 @@ defmodule XMLRPC.Encoder do
 end
 
 
-# ##########################################################################
+  # ##########################################################################
 
 defprotocol XMLRPC.ValueEncoder do
   @fallback_to_any true
@@ -113,9 +113,9 @@ defimpl XMLRPC.ValueEncoder, for: Atom do
   def encode(false, _options), do: tag("boolean", "0")
 
   def encode(atom, _options), do: tag("string",
-    atom
-    |> Atom.to_string
-    |> escape_attr )
+                                      atom
+                                      |> Atom.to_string
+                                      |> escape_attr )
 end
 
 
@@ -124,7 +124,7 @@ defimpl XMLRPC.ValueEncoder, for: BitString do
 
   def encode(string, _options) do
     tag("string",
-      escape_attr(string))
+        escape_attr(string))
   end
 end
 
@@ -164,7 +164,7 @@ defimpl XMLRPC.ValueEncoder, for: XMLRPC.Base64 do
   import XMLRPC.Encode, only: [tag: 2]
 
   def encode(%XMLRPC.Base64{raw: base64}, _options) do
-    tag("base64", base64)
+      tag("base64", base64)
   end
 end
 
@@ -173,9 +173,9 @@ defimpl XMLRPC.ValueEncoder, for: List do
   import XMLRPC.Encode, only: [tag: 2]
 
   def encode(array, options) do
-    tag("array",
-      tag("data",
-        array |> Enum.map(fn v -> XMLRPC.Encoder.encode_value(v, options) end) ) )
+      tag("array",
+        tag("data",
+          array |> Enum.map(fn v -> XMLRPC.Encoder.encode_value(v, options) end) ) )
   end
 end
 
@@ -185,8 +185,8 @@ defimpl XMLRPC.ValueEncoder, for: Map do
   # Parse a general map structure.
   # Note: This will also match structs, so define those above this definition
   def encode(struct, options) do
-    tag("struct",
-      struct |> Enum.map(fn m -> encode_member(m, options) end))
+      tag("struct",
+        struct |> Enum.map(fn m -> encode_member(m, options) end))
   end
 
   # Individual items of a struct. Basically key/value pair
@@ -213,6 +213,6 @@ defimpl XMLRPC.ValueEncoder, for: Any do
   end
 end
 
-# defp encode_value(_) do
-#   throw({:error, "Unknown value type"})
-# end
+  # defp encode_value(_) do
+  #   throw({:error, "Unknown value type"})
+  # end

--- a/lib/xml_rpc/encoder.ex
+++ b/lib/xml_rpc/encoder.ex
@@ -55,9 +55,9 @@ defmodule XMLRPC.Encoder do
 
   def encode!(%XMLRPC.MethodResponse{ param: param }, options) do
     ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>"] ++
-      tag("methodResponse",
-        tag("params",
-          encode_param(param, options)))
+    tag("methodResponse",
+      tag("params",
+        encode_param(param, options)))
   end
 
   def encode!(%XMLRPC.Fault{ fault_code: fault_code, fault_string: fault_string }, options) do
@@ -88,7 +88,7 @@ defmodule XMLRPC.Encoder do
 end
 
 
-  # ##########################################################################
+# ##########################################################################
 
 defprotocol XMLRPC.ValueEncoder do
   @fallback_to_any true
@@ -113,9 +113,9 @@ defimpl XMLRPC.ValueEncoder, for: Atom do
   def encode(false, _options), do: tag("boolean", "0")
 
   def encode(atom, _options), do: tag("string",
-                                      atom
-                                      |> Atom.to_string
-                                      |> escape_attr )
+    atom
+    |> Atom.to_string
+    |> escape_attr )
 end
 
 
@@ -124,7 +124,7 @@ defimpl XMLRPC.ValueEncoder, for: BitString do
 
   def encode(string, _options) do
     tag("string",
-        escape_attr(string))
+      escape_attr(string))
   end
 end
 
@@ -139,10 +139,14 @@ end
 defimpl XMLRPC.ValueEncoder, for: Float do
   import XMLRPC.Encode, only: [tag: 2]
 
-  def encode(double, _options) do
+  def encode(double, options) do
     # Something of a format hack in the absence of a proper pretty printer
     # On average will round trip a float back to the original simple string
-    tag("double", :erlang.float_to_binary(double, [{:decimals, 14}, :compact]))
+
+    tag("double", Float.to_string(double, options
+                                          |> Keyword.put_new(:compact, true)
+                                          |> Keyword.put_new(:decimals, 14))
+    )
   end
 end
 
@@ -160,7 +164,7 @@ defimpl XMLRPC.ValueEncoder, for: XMLRPC.Base64 do
   import XMLRPC.Encode, only: [tag: 2]
 
   def encode(%XMLRPC.Base64{raw: base64}, _options) do
-      tag("base64", base64)
+    tag("base64", base64)
   end
 end
 
@@ -169,9 +173,9 @@ defimpl XMLRPC.ValueEncoder, for: List do
   import XMLRPC.Encode, only: [tag: 2]
 
   def encode(array, options) do
-      tag("array",
-        tag("data",
-          array |> Enum.map(fn v -> XMLRPC.Encoder.encode_value(v, options) end) ) )
+    tag("array",
+      tag("data",
+        array |> Enum.map(fn v -> XMLRPC.Encoder.encode_value(v, options) end) ) )
   end
 end
 
@@ -181,8 +185,8 @@ defimpl XMLRPC.ValueEncoder, for: Map do
   # Parse a general map structure.
   # Note: This will also match structs, so define those above this definition
   def encode(struct, options) do
-      tag("struct",
-        struct |> Enum.map(fn m -> encode_member(m, options) end))
+    tag("struct",
+      struct |> Enum.map(fn m -> encode_member(m, options) end))
   end
 
   # Individual items of a struct. Basically key/value pair
@@ -209,6 +213,6 @@ defimpl XMLRPC.ValueEncoder, for: Any do
   end
 end
 
-  # defp encode_value(_) do
-  #   throw({:error, "Unknown value type"})
-  # end
+# defp encode_value(_) do
+#   throw({:error, "Unknown value type"})
+# end


### PR DESCRIPTION
When we converting float to string, we can see repeating decimal there should be a fixed number of characters after point (128.39 -> "128.38999999999999").
For example:
```
iex(1)>  %XMLRPC.MethodCall{method_name: "test", params: [127.39]} |> XMLRPC.encode!  
"<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>test</methodName><params><param><value><double>127.39</double></value></param></params></methodCall>"
``` 
```
iex(2)>  %XMLRPC.MethodCall{method_name: "test", params: [128.39]} |> XMLRPC.encode!  
"<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>test</methodName><params><param><value><double>128.38999999999999</double></value></param></params></methodCall>"
```

The problem lies in the declared accuracy of calculations :erlang.float_to_binary
This problem can be solved by using [options] as parameter of encoding/2 function.

For example:
```
iex(3)>  %XMLRPC.MethodCall{method_name: "test", params: [128.39]} |> XMLRPC.encode!(decimals: 2)  
"<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>test</methodName><params><param><value><double>128.39</double></value></param></params></methodCall>"
```
or
```
iex(4)>  %XMLRPC.MethodCall{method_name: "test", params: [128.39]} |> XMLRPC.encode!([decimals: 2])  
"<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>test</methodName><params><param><value><double>128.39</double></value></param></params></methodCall>"
```